### PR TITLE
Remove un-implemented controls from search interface

### DIFF
--- a/src/js_src/containers/search/searchControls.js
+++ b/src/js_src/containers/search/searchControls.js
@@ -60,29 +60,44 @@ class SearchControlsComponent extends Component {
     );
   }
 
+  renderSortinator() {
+    return (
+      <div className={style.control}>
+        <label className={style.searchLabel}>Sort By</label>
+        <DropdownButton className='btn-secondary' id='bg-nested-dropdown' title='Relevance'>
+          <MenuItem eventKey='1'>Dropdown link</MenuItem>
+          <MenuItem eventKey='2'>Dropdown link</MenuItem>
+        </DropdownButton>
+      </div>
+    );
+  }
+
+  renderPageSizeControl() {
+    return (
+      <div className={style.control}>
+        <label className={style.searchLabel}>Page Size</label>
+        <DropdownButton className='btn-secondary' id='bg-nested-dropdown' title='50'>
+          <MenuItem eventKey='1'>Dropdown link</MenuItem>
+          <MenuItem eventKey='2'>Dropdown link</MenuItem>
+        </DropdownButton>
+      </div>
+    );
+  }
+
+  renderDownloadButton() {
+    return (
+      <div>
+        <label className={style.searchLabel}>&nbsp;</label>
+        <a className={`btn btn-secondary ${style.agrDownloadBtn}`} href='#'><i className='fa fa-download' /> Download</a>
+      </div>
+    );
+  }
+
   renderNonViewAs() {
     if (this.props.isMultiTable || this.props.mode === 'graph') return null;
     return (
       <div className={style.controlContainer}>
         {this.renderPaginator()}
-        <div className={style.control}>
-          <label className={style.searchLabel}>Sort By</label>
-          <DropdownButton className='btn-secondary' id='bg-nested-dropdown' title='Relevance'>
-            <MenuItem eventKey='1'>Dropdown link</MenuItem>
-            <MenuItem eventKey='2'>Dropdown link</MenuItem>
-          </DropdownButton>
-        </div>
-        <div className={style.control}>
-          <label className={style.searchLabel}>Page Size</label>
-          <DropdownButton className='btn-secondary' id='bg-nested-dropdown' title='50'>
-            <MenuItem eventKey='1'>Dropdown link</MenuItem>
-            <MenuItem eventKey='2'>Dropdown link</MenuItem>
-          </DropdownButton>
-        </div>
-        <div>
-          <label className={style.searchLabel}>&nbsp;</label>
-          <a className={`btn btn-secondary ${style.agrDownloadBtn}`} href='#'><i className='fa fa-download' /> Download</a>
-        </div>
       </div>
     );
   }

--- a/src/js_src/containers/search/style.css
+++ b/src/js_src/containers/search/style.css
@@ -1,7 +1,7 @@
 .controlContainer {
 	float: right;
 	margin-top: 0.25rem;
-	width: 548px;
+	width: 120px;
 	display: flex;
 	justify-content: space-between;
 }


### PR DESCRIPTION
Fixes #74 

I moved them to methods that aren't called yet, so they're stubbed out and ready to be used later