### PR TITLE
Hide RGD identifiers from human gene pages

### DIFF
--- a/src/js_src/components/dataSourceLink.js
+++ b/src/js_src/components/dataSourceLink.js
@@ -17,20 +17,22 @@ const URL_GENERATORS = {
 class DataSourceLink extends Component {
   render() {
     let linker = URL_GENERATORS[this.props.dataProvider];
+    let prefix = this.props.omitPrefix ? '' : `${this.props.dataProvider}:`;
     if (!linker) {
-      return <span>{this.props.dataProvider}:{this.props.id}</span>;
+      return <span>{prefix}{this.props.id}</span>;
     }
     return (
       <span>
-        {this.props.dataProvider}:<a href={linker(this.props.id)}>{this.props.id}</a>
+        {prefix}<a href={linker(this.props.id)}>{this.props.id}</a>
       </span>
     );
   }
 }
 
 DataSourceLink.propTypes = {
-  dataProvider: React.PropTypes.string,
-  id: React.PropTypes.string,
+  dataProvider: React.PropTypes.string.isRequired,
+  id: React.PropTypes.string.isRequired,
+  omitPrefix: React.PropTypes.bool,
 };
 
 export default DataSourceLink;

--- a/src/js_src/containers/genePage/basicGeneInfo.js
+++ b/src/js_src/containers/genePage/basicGeneInfo.js
@@ -23,6 +23,22 @@ class BasicGeneInfo extends Component {
     return <i className='text-muted'>Not Available</i>;
   }
 
+  renderCrossReferenceList() {
+    let refs = this.state.geneData.crossReferences;
+    if (!refs || refs.length < 1) {
+      return <i className='text-muted'>Not Available</i>;
+    }
+    return refs
+      .sort((a, b) => `${a.dataProvider}:${a.id}`.localeCompare(`${b.dataProvider}:${b.id}`))
+      .map((ref, idx) => {
+        return (
+          <div key={`ref-${idx}`}>
+            <DataSourceLink dataProvider={ref.dataProvider} id={ref.id} />
+          </div>
+        );
+      });
+  }
+
   render() {
     return (
       <div className='row'>
@@ -49,19 +65,7 @@ class BasicGeneInfo extends Component {
             <dd className='col-sm-10'>{this.placeholderIfBlank(this.state.geneData.geneSynopsis)}</dd>
 
             <dt className='col-sm-2'>Genomic Resources</dt>
-            <dd className='col-sm-10'>
-              {
-                this.state.geneData.crossReferences
-                  .sort((a, b) => `${a.dataProvider}:${a.id}`.localeCompare(`${b.dataProvider}:${b.id}`))
-                  .map((ref, idx) => {
-                    return (
-                      <div key={`ref-${idx}`}>
-                        <DataSourceLink dataProvider={ref.dataProvider} id={ref.id} />
-                      </div>
-                    );
-                  })
-              }
-            </dd>
+            <dd className='col-sm-10'>{this.renderCrossReferenceList()}</dd>
 
             <dt className='col-sm-2'>Additional Information</dt>
             <dd className='col-sm-10'><a href={this.state.geneData.geneLiteratureUrl}>Literature</a></dd>

--- a/src/js_src/containers/genePage/dataSourceCard.js
+++ b/src/js_src/containers/genePage/dataSourceCard.js
@@ -7,16 +7,17 @@ import style from './style.css';
 class DataSourceCard extends Component {
   render() {
     let d = this.props.sourceData;
+    let speciesClass = style[d.species.replace(' ', '-')];
     return (
       <div className='card'>
-        <div className={`${style.speciesIcon} ${style[d.dataProvider]}`} />
+        {speciesClass && <div className={`${style.speciesIcon} ${speciesClass}`} />}
         <div className='card-block'>
           <dl className='row'>
             <dt className='col-sm-5'>Species</dt>
             <dd className='col-sm-7'><i>{d.species}</i></dd>
             <dt className='col-sm-5'>Primary Source</dt>
             <dd className='col-sm-7'>
-              <DataSourceLink dataProvider={d.dataProvider} id={d.primaryId} />
+              <DataSourceLink dataProvider={d.dataProvider} id={d.primaryId} omitPrefix />
             </dd>
           </dl>
         </div>
@@ -26,7 +27,11 @@ class DataSourceCard extends Component {
 }
 
 DataSourceCard.propTypes = {
-  sourceData: React.PropTypes.object
+  sourceData: React.PropTypes.shape({
+    species: React.PropTypes.string.isRequired,
+    dataProvider: React.PropTypes.string.isRequired,
+    primaryId: React.PropTypes.string.isRequired,
+  }).isRequired,
 };
 
 export default DataSourceCard;

--- a/src/js_src/containers/genePage/style.css
+++ b/src/js_src/containers/genePage/style.css
@@ -17,26 +17,26 @@
   }
 }
 
-.speciesIcon.FB {
+.speciesIcon.Drosophila-melanogaster { /* fly */
   background-position: 0 0;
 }
 
-.speciesIcon.RGD {
+.speciesIcon.Rattus-norvegicus { /* rat */
   background-position: 0 -91px;
 }
 
-.speciesIcon.MGI {
+.speciesIcon.Mus-musculus { /* mouse */
   background-position: 0 -182px;
 }
 
-.speciesIcon.SGD {
+.speciesIcon.Saccharomyces-cerevisiae { /* yeast */
   background-position: 0 -273px;
 }
 
-.speciesIcon.WB {
+.speciesIcon.Caenorhabditis-elegans { /* worm */
   background-position: 0 -364px;
 }
 
-.speciesIcon.ZFIN {
+.speciesIcon.Danio-rerio { /* zebrafish */
   background-position: 0 -455px;
 }


### PR DESCRIPTION
This change makes the species icon actually keyed off of species instead of data provider. In particular that means there will just be no species icon shown for human at the moment (because there isn't one). It also drops the data provider prefix for all Primary Source links, which fixes the "RGD:HGNC:XXXX" issue.

Fixes #155 