### PR TITLE
Improved iterative loading and removed pickle files AGR-257

### DIFF
--- a/indexer/Makefile
+++ b/indexer/Makefile
@@ -7,17 +7,11 @@ OPTIONS = ES_HOST=$(ES_HOST) ES_AWS=$(ES_AWS) ES_INDEX=$(ES_INDEX)
 install:
 	pip install -r requirements.txt
 
-fetch_and_save:
-	cd src && $(OPTIONS) python fetch_and_save.py
-
-load_and_index:
-	cd src && $(OPTIONS) python load_and_index.py
-
 index:
-	cd src && $(OPTIONS) python fetch_save_index.py
+	cd src && $(OPTIONS) python fetch_index.py
 
 test_index:
-	cd src && $(OPTIONS) python fetch_save_test_index.py
+	cd src && $(OPTIONS) python fetch_test_index.py
 
 test:
 	$(OPTIONS) nosetests -s

--- a/indexer/src/fetch_index.py
+++ b/indexer/src/fetch_index.py
@@ -1,0 +1,8 @@
+from loaders import *
+
+if __name__ == '__main__':
+    al = AggregateLoader()
+    al.establish_index()
+    al.load_annotations()
+    al.load_from_mods(test_set = 'false')
+    al.index_data()

--- a/indexer/src/fetch_index.py
+++ b/indexer/src/fetch_index.py
@@ -4,5 +4,5 @@ if __name__ == '__main__':
     al = AggregateLoader()
     al.establish_index()
     al.load_annotations()
-    al.load_from_mods(test_set = 'false')
+    al.load_from_mods(test_set = False)
     al.index_data()

--- a/indexer/src/fetch_test_index.py
+++ b/indexer/src/fetch_test_index.py
@@ -4,5 +4,5 @@ if __name__ == '__main__':
     al = AggregateLoader()
     al.establish_index()
     al.load_annotations()
-    al.load_from_mods(test_set = 'true')
+    al.load_from_mods(test_set = True)
     al.index_data()

--- a/indexer/src/fetch_test_index.py
+++ b/indexer/src/fetch_test_index.py
@@ -1,0 +1,8 @@
+from loaders import *
+
+if __name__ == '__main__':
+    al = AggregateLoader()
+    al.establish_index()
+    al.load_annotations()
+    al.load_from_mods(test_set = 'true')
+    al.index_data()

--- a/indexer/src/loaders/aggregate_loader.py
+++ b/indexer/src/loaders/aggregate_loader.py
@@ -23,12 +23,6 @@ class AggregateLoader:
         self.es = ESMapping(os.environ['ES_HOST'], os.environ['ES_INDEX'], os.environ['ES_AWS'], self.chunk_size)
         self.es.start_index()
 
-    def load_from_files(self):
-        print "Loading data from saved files"
-        self.go_dataset = PickleFile("tmp/go_bkp.pickle").load()
-        self.so_dataset = PickleFile("tmp/so_bkp.pickle").load()
-        self.do_dataset = PickleFile("tmp/do_bkp.pickle").load()
-
     def load_annotations(self):
         print "Loading GO Data"
         self.go_dataset = GoLoader().get_data()
@@ -37,33 +31,26 @@ class AggregateLoader:
         print "Loading DO Data"
         self.do_dataset = DoLoader().get_data()
 
-    def load_from_mods(self, pickle, index, test_set):
+    def load_from_mods(self, test_set):
         mods = [RGD(), MGI(), ZFIN(), SGD(), WormBase(), FlyBase(), Human()]
+
+        gene_master_dict = {} # Build a dictionary of sets for all indexed MODs/genes. Used for filtering orthology.
 
         self.test_set = test_set
         if self.test_set == 'true':
             print "WARNING: test_set is enabled -- only indexing test genes."
             time.sleep(3)
 
-        print "Gathering genes from each MOD"
+        print "Gathering genes from each MOD."
         for mod in mods:
 
-            pickle_file_name = "tmp/genes_bkp_%s.pickle" % (mod.__class__.__name__)
-            if pickle == 'save':
-                try:
-                    print "Removing %s if it exists." % (pickle_file_name)
-                    os.remove(pickle_file_name)
-                except OSError:
-                    pass
+            gene_master_dict[mod.__class__.__name__] = set()
 
             genes = mod.load_genes(self.batch_size, self.test_set) # generator object
             print "Loading GO annotations for %s" % (mod.species)
             gene_go_annots = mod.load_go()
             print "Loading DO annotations for %s" % (mod.species)
             disease_annots = mod.load_diseases()
-
-            print "Loading Orthology data for %s" % (mod.species)
-            ortho_dataset = OrthoLoader().get_data(mod.__class__.__name__, self.test_set)
 
             for gene_list_of_entries in genes:
                 # Annotations to individual genes occurs in the loop below via static methods.
@@ -74,30 +61,33 @@ class AggregateLoader:
                     (gene_list_of_entries[item], self.go_dataset) = GoAnnotator().attach_annotations(individual_gene, gene_go_annots, self.go_dataset)
                     gene_list_of_entries[item] = DoAnnotator().attach_annotations(individual_gene, disease_annots, self.do_dataset)
                     gene_list_of_entries[item] = SoAnnotator().attach_annotations(individual_gene, self.so_dataset)
-                    gene_list_of_entries[item] = OrthoAnnotator().attach_annotations(individual_gene, ortho_dataset)
+                    gene_master_dict[mod.__class__.__name__].add(individual_gene['primaryId'])
 
-                if pickle == 'save':
-                    PickleFile(pickle_file_name).save_append(gene_list_of_entries)
+                self.es.index_data(gene_list_of_entries, 'Gene Data', 'index') # Load genes into ES
 
-                if index == 'true':
-                    self.es.index_data(gene_list_of_entries, 'Gene Data', 'index') # Load genes into ES
-
-    def index_mods_from_pickle(self):
-        mods = [RGD(), MGI(), ZFIN(), SGD(), WormBase(), FlyBase(), Human()]
-
+        print "Processing orthology data for each MOD."
         for mod in mods:
-            list_to_load = []
-            pickle_file_name = "tmp/genes_bkp_%s.pickle" % (mod.__class__.__name__)
-            gene_pickle = PickleFile(pickle_file_name).load_multi() # generator object
 
-            for gene in gene_pickle:
-                self.es.index_data(list_to_load, 'Gene Data', 'index') # Load genes into ES
+            list_to_index = []
 
-    def save_to_files(self):
-        print "Saving processed data to files"
-        PickleFile("tmp/go_bkp.pickle").save(self.go_dataset)
-        PickleFile("tmp/so_bkp.pickle").save(self.so_dataset)
-        PickleFile("tmp/do_bkp.pickle").save(self.do_dataset)
+            print "Loading Orthology data for %s" % (mod.species)
+            ortho_dataset = OrthoLoader().get_data(mod.__class__.__name__, self.test_set, gene_master_dict[mod.__class__.__name__])
+
+            for gene in gene_master_dict[mod.__class__.__name__]:
+                # Create a simple dictionary for each entry.
+                individual_gene = {
+                    'primaryId' : gene,
+                    'orthology' : []
+                    }
+                individual_gene = OrthoAnnotator().attach_annotations(individual_gene, ortho_dataset)
+
+                list_to_index.append(individual_gene)
+                if len(list_to_index) == self.batch_size:
+                    self.es.update_data(list_to_index) # Load genes into ES
+                    list_to_index[:] = []  # Empty the list.
+
+            if len(list_to_index) > 0:
+                self.es.update_data(list_to_index) # Load genes into ES    
 
     def index_data(self):
         self.es.index_data(self.go_dataset, 'GO Data', 'index') # Load the GO dataset into ES

--- a/indexer/src/loaders/aggregate_loader.py
+++ b/indexer/src/loaders/aggregate_loader.py
@@ -71,7 +71,7 @@ class AggregateLoader:
             list_to_index = []
 
             print "Loading Orthology data for %s" % (mod.species)
-            ortho_dataset = OrthoLoader().get_data(mod.__class__.__name__, self.test_set, gene_master_dict[mod.__class__.__name__])
+            ortho_dataset = OrthoLoader().get_data(mod.__class__.__name__, self.test_set, gene_master_dict)
 
             for gene in gene_master_dict[mod.__class__.__name__]:
                 # Create a simple dictionary for each entry.

--- a/indexer/src/loaders/aggregate_loader.py
+++ b/indexer/src/loaders/aggregate_loader.py
@@ -37,7 +37,7 @@ class AggregateLoader:
         gene_master_dict = {} # Build a dictionary of sets for all indexed MODs/genes. Used for filtering orthology.
 
         self.test_set = test_set
-        if self.test_set == 'true':
+        if self.test_set == True:
             print "WARNING: test_set is enabled -- only indexing test genes."
             time.sleep(3)
 

--- a/indexer/src/loaders/gene_loader.py
+++ b/indexer/src/loaders/gene_loader.py
@@ -40,9 +40,9 @@ class GeneLoader:
             if geneRecord['taxonId'] == "NCBITaxon:9606" or geneRecord['taxonId'] == "NCBITaxon:10090":
                 local_id = geneRecord['primaryId']
 
-            if test_set == 'true':
+            if test_set == True:
                 is_it_test_entry = check_for_test_entry(primary_id)
-                if is_it_test_entry == 'false':
+                if is_it_test_entry == False:
                     continue
 
             if 'crossReferenceIds' in geneRecord:

--- a/indexer/src/loaders/ortho_loader.py
+++ b/indexer/src/loaders/ortho_loader.py
@@ -48,12 +48,13 @@ class OrthoLoader:
             if gene1AgrPrimaryId not in ortho_dataset:
                 ortho_dataset[gene1AgrPrimaryId] = []
             gene2_found = None
-            for mod_gene_set in gene_master_dict:
-                if gene2AgrPrimaryId in gene_master_dict[mod_gene_set]:
-                    gene2_found = True
-                    break
-            if gene2_found is None:
-                continue # Skip entries where we don't have gene 2 in AGR.
+            if test_set is not 'true':
+                for mod_gene_set in gene_master_dict:
+                    if gene2AgrPrimaryId in gene_master_dict[mod_gene_set]:
+                        gene2_found = True
+                        break
+                if gene2_found is None:
+                    continue # Skip entries where we don't have gene 2 in AGR.
             ortho_dataset[gene1AgrPrimaryId].append({
                 'isBestScore': orthoRecord['isBestScore'],
                 'isBestRevScore': orthoRecord['isBestRevScore'],

--- a/indexer/src/loaders/ortho_loader.py
+++ b/indexer/src/loaders/ortho_loader.py
@@ -8,7 +8,7 @@ from test_check import check_for_test_entry
 class OrthoLoader:
 
     @staticmethod
-    def get_data(mod_name, test_set, gene_master_set):
+    def get_data(mod_name, test_set, gene_master_dict):
         path = "tmp"
         filename = None
         filename_comp = None
@@ -47,7 +47,12 @@ class OrthoLoader:
 
             if gene1AgrPrimaryId not in ortho_dataset:
                 ortho_dataset[gene1AgrPrimaryId] = []
-            if gene2AgrPrimaryId not in gene_master_set:
+            gene2_found = None
+            for mod_gene_set in gene_master_dict:
+                if gene2AgrPrimaryId in gene_master_dict[mod_gene_set]:
+                    gene2_found = True
+                    break
+            if gene2_found is None:
                 continue # Skip entries where we don't have gene 2 in AGR.
             ortho_dataset[gene1AgrPrimaryId].append({
                 'isBestScore': orthoRecord['isBestScore'],

--- a/indexer/src/loaders/ortho_loader.py
+++ b/indexer/src/loaders/ortho_loader.py
@@ -12,7 +12,7 @@ class OrthoLoader:
         path = "tmp"
         filename = None
         filename_comp = None
-        if test_set == 'true':
+        if test_set == True:
             filename = '/orthology_test_data_0.6.1_3.json'
             filename_comp = 'orthology_test_data_0.6.1_3.json.tar.gz'
         else:
@@ -47,8 +47,8 @@ class OrthoLoader:
 
             if gene1AgrPrimaryId not in ortho_dataset:
                 ortho_dataset[gene1AgrPrimaryId] = []
-            gene2_found = None
-            if test_set is not 'true':
+            if test_set is not True:
+                gene2_found = None
                 for mod_gene_set in gene_master_dict:
                     if gene2AgrPrimaryId in gene_master_dict[mod_gene_set]:
                         gene2_found = True

--- a/indexer/src/loaders/ortho_loader.py
+++ b/indexer/src/loaders/ortho_loader.py
@@ -8,7 +8,7 @@ from test_check import check_for_test_entry
 class OrthoLoader:
 
     @staticmethod
-    def get_data(mod_name, test_set):
+    def get_data(mod_name, test_set, gene_master_set):
         path = "tmp"
         filename = None
         filename_comp = None
@@ -47,6 +47,8 @@ class OrthoLoader:
 
             if gene1AgrPrimaryId not in ortho_dataset:
                 ortho_dataset[gene1AgrPrimaryId] = []
+            if gene2AgrPrimaryId not in gene_master_set:
+                continue # Skip entries where we don't have gene 2 in AGR.
             ortho_dataset[gene1AgrPrimaryId].append({
                 'isBestScore': orthoRecord['isBestScore'],
                 'isBestRevScore': orthoRecord['isBestRevScore'],

--- a/indexer/src/loaders/test_check.py
+++ b/indexer/src/loaders/test_check.py
@@ -8,6 +8,6 @@ def check_for_test_entry(primary_id):
                 'SGD:S000003256', 'SGD:S000003513', 'SGD:S000000119', 'SGD:S000001015'}
 
     if primary_id in test_set:
-        return 'true'
+        return True
     else:
-        return 'false'
+        return False

--- a/indexer/src/mapping/es_mapping.py
+++ b/indexer/src/mapping/es_mapping.py
@@ -99,3 +99,27 @@ class ESMapping:
                     print "A document failed: %s" % (info)
 
         print "Indexing took: " + str(time.time() - s) + " seconds"
+
+    def update_data(self, data):
+        s = time.time()
+        bulk_data = []
+
+        print "Updating Genes in Index: %s." % (self.new_index_name)
+
+        for entry in data:
+            id_to_use = entry['primaryId']
+                
+            doc = { 
+                '_op_type': 'update',
+                '_index': self.new_index_name, 
+                '_type': "searchable_item",
+                '_id': id_to_use,
+                'doc': entry
+            }
+            bulk_data.append(doc)
+
+        for success, info in streaming_bulk(self.es, actions=bulk_data, refresh=False, request_timeout=60, chunk_size=self.chunk_size):
+                if not success:
+                    print "A document failed: %s" % (info)
+
+        print "Indexing took: " + str(time.time() - s) + " seconds"


### PR DESCRIPTION
A few important changes to the indexer:

- Loading is now separated into two iterations. We can filter out data if specific genes do not exist in the ES index after all Basic Gene Information is loaded.
- Orthology data is now filtered to skip entries where the orthologous gene does not exist in the ES index. 
- Pickle file saving / loading is removed. No one was using them and this speeds up indexing.
