### PR TITLE
AGR-413  Hide disease records that come back as genes

### DIFF
--- a/api/src/services/helpers/search_helper.py
+++ b/api/src/services/helpers/search_helper.py
@@ -133,12 +133,19 @@ def build_search_params(query, search_fields):
     if query is "":
         es_query = {"match_all": {}}
     else:
-        es_query = {'dis_max': {'queries': []}}
+        es_query = {'bool':
+                        {'must': [
+                             {'dis_max': {'queries': []}},
+                             {'exists': {'field': 'category'}}
+                            ]
+                         }
+        }
+
 
         if (query[0] in ('"', "'") and query[-1] in ('"', "'")):
             query = query[1:-1]
 
-        es_query['dis_max']['queries'] = []
+        es_query['bool']['must'][0]['dis_max']['queries'] = []
 
         custom_boosts = {
             "primaryId": 400,
@@ -173,8 +180,8 @@ def build_search_params(query, search_fields):
                 'query': query
             }
 
-            es_query['dis_max']['queries'].append({'match': match})
-            es_query['dis_max']['queries'].append({'match_phrase_prefix': partial_match})
+            es_query['bool']['must'][0]['dis_max']['queries'].append({'match': match})
+            es_query['bool']['must'][0]['dis_max']['queries'].append({'match_phrase_prefix': partial_match})
 
     return es_query
 

--- a/api/test/unit_tests/test_search.py
+++ b/api/test/unit_tests/test_search.py
@@ -56,8 +56,17 @@ class SearchHelpersTest(unittest.TestCase):
 
         self.maxDiff = None
         self.assertEqual(build_search_params(query, fields), {
-            'dis_max': {
-                'queries': self._query_builder("gene", fields)
+            "bool": {
+                "must": [
+                    {
+                        "dis_max": {
+                            'queries': self._query_builder("gene", fields)
+                        }
+                    },
+                    {
+                        "exists": {"field": "category"}
+                    }
+                ]
             }
         })
 
@@ -66,8 +75,17 @@ class SearchHelpersTest(unittest.TestCase):
         fields = ["name", "symbol"]
 
         self.assertEqual(build_search_params(query, fields), {
-            "dis_max": {
-                "queries": self._query_builder(query, fields)
+            "bool": {
+                "must": [
+                    {
+                        "dis_max": {
+                            "queries": self._query_builder(query, fields)
+                        }
+                    },
+                    {
+                        "exists": {"field": "category"}
+                    }
+                ]
             }
         })
 
@@ -76,9 +94,19 @@ class SearchHelpersTest(unittest.TestCase):
         fields = ["name", "symbol"]
 
         self.assertEqual(build_search_params(query, fields), {
-            "dis_max": {
-                "queries": self._query_builder(query[1:-1], fields)
+            "bool": {
+                "must": [
+                    {
+                        "dis_max": {
+                            "queries": self._query_builder(query[1:-1], fields)
+                        }
+                    },
+                    {
+                        "exists": {"field": "category"}
+                    }
+                ]
             }
+
         })
 
     def test_build_search_query_should_return_search_params_only_for_no_category(self):


### PR DESCRIPTION
I excluded any record with a null category from coming back in the results.